### PR TITLE
Add win_facts and fail_facts to EnvInfos.

### DIFF
--- a/textworld/core.py
+++ b/textworld/core.py
@@ -20,7 +20,8 @@ class EnvInfos:
     """
 
     __slots__ = ['feedback', 'description', 'inventory', 'location',
-                 'facts', 'last_action', 'last_command',
+                 'facts', 'win_facts', 'fail_facts',
+                 'last_action', 'last_command',
                  'game',
                  'won', 'lost',
                  'score', 'moves', 'max_score', 'objective',
@@ -47,6 +48,12 @@ class EnvInfos:
         #: bool: All the facts that are currently true about the world.
         #:       This information changes from one step to another.
         self.facts = kwargs.get("facts", False)
+        #: bool: Mutually exclusive sets of winning facts for each quest.
+        #:       This information *doesn't* change from one step to another.
+        self.win_facts = kwargs.get("win_facts", False)
+        #: bool: Mutually exclusive sets of failing facts for each quest.
+        #:       This information *doesn't* change from one step to another.
+        self.fail_facts = kwargs.get("fail_facts", False)
         #: bool: The last action performed where `None` means it was not a valid action.
         #:       This information changes from one step to another.
         self.last_action = kwargs.get("last_action", False)

--- a/textworld/envs/wrappers/tests/test_tw_inform7.py
+++ b/textworld/envs/wrappers/tests/test_tw_inform7.py
@@ -294,6 +294,8 @@ class TestGameData(unittest.TestCase):
         cls.infos = EnvInfos(
             max_score=True,
             objective=True,
+            win_facts=True,
+            fail_facts=True,
         )
 
     @classmethod
@@ -322,6 +324,30 @@ class TestGameData(unittest.TestCase):
             assert initial_state.objective.strip() in initial_state.feedback
             game_state, _, _ = env.step("goal")
             assert game_state.feedback.strip() == initial_state.objective
+
+    def test_win_facts(self):
+        for env in [self.env_ulx, self.env_z8]:
+            initial_state = env.reset()
+            assert len(initial_state.win_facts) == len(self.game.quests)
+            for i, quest in enumerate(self.game.quests):
+                assert len(initial_state.win_facts[i]) == len(quest.win_events)
+                for j, event in enumerate(quest.win_events):
+                    assert len(initial_state.win_facts[i][j]) == len(event.condition.preconditions)
+
+            game_state, _, _ = env.step("look")
+            assert game_state.win_facts == initial_state.win_facts
+
+    def test_fail_facts(self):
+        for env in [self.env_ulx, self.env_z8]:
+            initial_state = env.reset()
+            assert len(initial_state.fail_facts) == len(self.game.quests)
+            for i, quest in enumerate(self.game.quests):
+                assert len(initial_state.fail_facts[i]) == len(quest.fail_events)
+                for j, event in enumerate(quest.fail_events):
+                    assert len(initial_state.fail_facts[i][j]) == len(event.condition.preconditions)
+
+            game_state, _, _ = env.step("look")
+            assert game_state.fail_facts == initial_state.fail_facts
 
     def test_missing_game_infos_file(self):
         with make_temp_directory() as tmpdir:

--- a/textworld/generator/game.py
+++ b/textworld/generator/game.py
@@ -560,16 +560,6 @@ class Game:
         return sorted(set(cmd.split()[0] for cmd in self.command_templates))
 
     @property
-    def win_conditions(self) -> List[Tuple[Event]]:
-        """ All win conditions, one for each quest. """
-        return [q.win_events for q in self.quests]
-
-    @property
-    def fail_conditions(self) -> List[Tuple[Event]]:
-        """ All fail conditions, one for each quest. """
-        return [q.fail_events for q in self.quests]
-
-    @property
     def objective(self) -> str:
         if self._objective is not None:
             return self._objective


### PR DESCRIPTION
Would something like this work for your use case?

```python
import textworld
from textworld import EnvInfos

infos = EnvInfos(..., win_facts=True, fail_facts=True, ...)
env = textworld.start('my_game.z8', infos)
state = env.reset()

import pprint
pprint.pprint(state["win_facts"])
pprint.pprint(state["fail_facts"])
...
```